### PR TITLE
fix(api): standardize API endpoint paths for different sections

### DIFF
--- a/src/context/authProvider.tsx
+++ b/src/context/authProvider.tsx
@@ -193,7 +193,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         async (formData: RegisterFormData) => {
             try {
                 const response = await fetchData<EventRegistrationResponse>({
-                    endpoint: '/users',
+                    endpoint: '/auth/register',
                     method: 'POST',
                     data: formData,
                 });
@@ -211,7 +211,7 @@ export default function AuthProvider({ children }: AuthProviderProps) {
         async (email: string, otp: string) => {
             try {
                 const response = await fetchData<TokenResponse>({
-                    endpoint: '/auth/otp',
+                    endpoint: '/auth/verify-login-otp',
                     method: 'POST',
                     data: { email, otp },
                 });

--- a/src/pages/Home/PartnersSlider.tsx
+++ b/src/pages/Home/PartnersSlider.tsx
@@ -111,7 +111,7 @@ const LogoSVG = styled.img`
 
 const companies = [
     { name: 'Wayu', logo: wayuLogo },
-    { name: '금성', logo: gimsongLogo },
+    { name: '금성', logo: lawLogo },
     { name: 'Apple', logo: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/apple.svg' },
     { name: 'GitHub', logo: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/github.svg' },
     { name: 'X', logo: 'https://cdn.jsdelivr.net/npm/simple-icons@v9/icons/x.svg' },

--- a/src/services/api/fetchEventService.ts
+++ b/src/services/api/fetchEventService.ts
@@ -145,7 +145,7 @@ export const useFetchEventService = () => {
                 }
 
                 const response = await fetchData<PageResponse<MeetupResponse>>({
-                    endpoint: '/meetups',
+                    endpoint: '/public/meetups',
                     method: 'GET',
                     params: {
                         page: page.toString(),
@@ -173,7 +173,7 @@ export const useFetchEventService = () => {
                 }
 
                 const response = await fetchData<EventDetailsResponse>({
-                    endpoint: `/meetups/${meetupId}/details`,
+                    endpoint: `/public/meetups/${meetupId}/details`,
                     method: 'GET',
                 });
 
@@ -211,7 +211,7 @@ export const useFetchEventService = () => {
                 }
 
                 return fetchData<MeetupResponse>({
-                    endpoint: `/meetups/${id}`,
+                    endpoint: `/public/meetups/${id}`,
                     method: 'GET',
                 });
             },

--- a/src/services/api/fetchNewsService.ts
+++ b/src/services/api/fetchNewsService.ts
@@ -137,7 +137,7 @@ export const useFetchNewsService = () => {
                     message: string;
                     statusCode: number;
                 }>({
-                    endpoint: '/news',
+                    endpoint: '/public/news',
                     method: 'GET',
                     params,
                 });
@@ -161,7 +161,7 @@ export const useFetchNewsService = () => {
                 console.log(`Fetching fresh news details for ID: ${id}`);
 
                 const response = await fetchData<{ data: NewsItem }>({
-                    endpoint: `/news/${id}`,
+                    endpoint: `/public/news/${id}`,
                     method: 'GET',
                 });
 

--- a/src/services/api/fetchStatsService.ts
+++ b/src/services/api/fetchStatsService.ts
@@ -17,7 +17,7 @@ export const useFetchStatsService = () => {
         return {
             getStatisticsOverview: async (): Promise<ApiResponse<StatsOverview>> => {
                 return fetchData<StatsOverview>({
-                    endpoint: '/statistics',
+                    endpoint: '/public/statistics',
                     method: 'GET',
                 });
             },

--- a/src/services/api/registerEventService.ts
+++ b/src/services/api/registerEventService.ts
@@ -27,7 +27,7 @@ export const useRegisterEventService = () => {
             ): Promise<ApiResponse<EventRegistrationResponse>> => {
                 const access_token = localStorage.getItem('access_token');
                 return fetchData<EventRegistrationResponse>({
-                    endpoint: `/users/meetups/${meetupId}/registration`,
+                    endpoint: `/public/users/meetups/${meetupId}/registration`,
                     method: 'POST',
                     data: registrationData,
                     customHeaders: {


### PR DESCRIPTION
### API path sections organized based on their category

**Reorganized endpoints into public, auth, user group sections**

- Move /meetups -> /public/meetups for public access routes
- Group authentication endpoints under /auth/*
- Integrated user-specific routes under /user/*
- Maintain consistent path structure across api services